### PR TITLE
Fixes #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .bsp
 /target
 /logs/
+/output/*
 /dags/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ FROM python:3.11-bullseye
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends openjdk-17-jdk
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-ENV SPARK_HOME="/opt/spark"
+ENV SPARK_HOME="/home/sparkuser/spark"
 ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
 ENV PATH="${JAVA_HOME}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 RUN mkdir -p ${SPARK_HOME}
 WORKDIR ${SPARK_HOME}
 
 # If it breaks in this step go to https://dlcdn.apache.org/spark/ and choose higher spark version instead
-RUN curl https://dlcdn.apache.org/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz -o spark-3.5.5-bin-hadoop3.tgz \
-    && tar xvzf spark-3.5.5-bin-hadoop3.tgz --directory ${SPARK_HOME} --strip-components 1 \
-    && rm -rf spark-3.5.5-bin-hadoop3.tgz
+RUN curl https://dlcdn.apache.org/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz -o spark-3.5.6-bin-hadoop3.tgz \
+    && tar xvzf spark-3.5.6-bin-hadoop3.tgz --directory ${SPARK_HOME} --strip-components 1 \
+    && rm -rf spark-3.5.6-bin-hadoop3.tgz
 # Port master will be exposed
 ENV SPARK_MASTER_PORT="7077"
 # Name of master container and also counts as hostname
@@ -29,6 +29,12 @@ RUN wget -P ${SPARK_HOME}/jars/ https://jdbc.postgresql.org/download/postgresql-
 # Download aws jar and add it to spark jars
 RUN wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar;
 RUN wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar;
+
+
+RUN useradd -u 1000 -m -d /home/sparkuser sparkuser
+ENV HOME="/home/sparkuser"
+RUN chown -R 1000:1000 ${SPARK_HOME}
+USER sparkuser
 
 COPY ./spark-defaults.conf "${SPARK_HOME}/conf"
 

--- a/Dockerfile.airflow
+++ b/Dockerfile.airflow
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends openjdk-17-jdk
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV SPARK_HOME="/opt/spark"
+ENV SPARK_HOME="/home/sparkuser/spark"
 ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
 ENV PATH="${JAVA_HOME}:${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 
@@ -18,15 +18,17 @@ ENV SPARK_MASTER_HOST="spark-master"
 
 RUN mkdir -p ${SPARK_HOME}
 # If it breaks in this step go to https://dlcdn.apache.org/spark/ and choose higher spark version instead
-RUN curl https://dlcdn.apache.org/spark/spark-3.5.5/spark-3.5.5-bin-hadoop3.tgz -o spark-3.5.5-bin-hadoop3.tgz \
-    && tar xvzf spark-3.5.5-bin-hadoop3.tgz --directory ${SPARK_HOME} --strip-components 1 \
-    && rm -rf spark-3.5.5-bin-hadoop3.tgz
+RUN curl https://dlcdn.apache.org/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz -o spark-3.5.6-bin-hadoop3.tgz \
+    && tar xvzf spark-3.5.6-bin-hadoop3.tgz --directory ${SPARK_HOME} --strip-components 1 \
+    && rm -rf spark-3.5.6-bin-hadoop3.tgz
 
-COPY ./spark-defaults.conf "${SPARK_HOME}/conf"
-
-RUN chown -R airflow ${SPARK_HOME}
+RUN useradd -u 1000 -m -d /home/sparkuser sparkuser
+ENV HOME="/home/sparkuser"
+RUN chown -R airflow:sparkuser ${SPARK_HOME}
 
 RUN apt update
 RUN apt-get -y install procps
+
+COPY ./spark-defaults.conf "${SPARK_HOME}/conf"
 
 USER airflow

--- a/README.md
+++ b/README.md
@@ -39,7 +39,18 @@ If you want to create a jar including only the base classes and no external depe
 
 To submit fat jar created using sbt-assembly use:
 
-for postgres example:
+for Parquet example:
+```markdown 
+spark-submit \
+    --class SparkParquetExample \
+    --master spark://spark-master:7077 \
+    --executor-memory 8G  \
+    --total-executor-cores 2 \
+    target/scala-2.12/sparkpg-assembly-1.0.jar \
+    output
+```
+
+for PostgreSQL example:
 ```markdown 
 spark-submit \
     --class SparkPostgresExample \
@@ -69,8 +80,8 @@ spark-submit \
     target/scala-2.12/sparkpg-assembly-1.0.jar
 ```
 There are also examples located inside spark, that you use can use for testing the UI for example for scala:
-- Find code examples and the class names to reference in /opt/spark/examples/src/main/scala/org/apache/spark/examples
-- Submit them by using the jar /opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar (exact jar path may vary based on spark installation)
+- Find code examples and the class names to reference in /home/sparkuser/spark/examples/src/main/scala/org/apache/spark/examples
+- Submit them by using the jar /home/sparkuser/spark/examples/jars/spark-examples_2.12-3.5.5.jar (exact jar path may vary based on spark installation)
 
 
 Example run localy with 1 executor:
@@ -78,7 +89,7 @@ Example run localy with 1 executor:
 spark-submit \
     --class org.apache.spark.examples.AccumulatorMetricsTest \
     --master local[1]  \
-    /opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar
+    /home/sparkuser/spark/examples/jars/spark-examples_2.12-3.5.5.jar
 ```
 
 Example run on Spark standalone cluster in client deploy mode:
@@ -88,7 +99,7 @@ spark-submit \
     --master spark://spark-master:7077 \
     --executor-memory 8G \
     --total-executor-cores 2 \
-    /opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar
+/home/sparkuser/spark/examples/jars/spark-examples_2.12-3.5.5.jar
 ```
 Running jobs using Airflow:
 - Once services are up and running navigate to [airflow web url](http://localhost:8090/)

--- a/dags/spark.py
+++ b/dags/spark.py
@@ -16,9 +16,20 @@ with DAG(
 
     accumulator_metrics = SparkSubmitOperator(
         task_id = "AccumulatorMetricsClient",
-        application = "/opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar",
+        application = "/home/sparkuser/spark/examples/jars/spark-examples_2.12-3.5.6.jar",
         conn_id = "spark_standalone_client",
         java_class='org.apache.spark.examples.AccumulatorMetricsTest',
+        executor_cores=2,
+        total_executor_cores=2,
+        verbose=True
+    )
+
+    spark_parquet = SparkSubmitOperator(
+        task_id = "SparkParquetExampleClient",
+        application = "/app/target/scala-2.12/sparkpg-assembly-1.0.jar",
+        conn_id = "spark_standalone_client",
+        java_class='SparkParquetExample',
+        application_args=['file:///app/output/'],
         executor_cores=2,
         total_executor_cores=2,
         verbose=True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,12 +26,12 @@ x-airflow-common:
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
     - .:/app
-    - spark-events:/opt/spark/events
+    - spark-events:/home/sparkuser/spark/events
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
-  user: "${AIRFLOW_UID:-50000}:0"
+  user: "${AIRFLOW_UID:-50000}:1000"
   depends_on:
     &airflow-common-depends-on
     redis:
@@ -50,7 +50,8 @@ services:
     profiles:
       - build
     entrypoint: /bin/bash
-    command: -c "cd /app; sbt assembly; chown -R "${AIRFLOW_UID}:1000" target"
+    command: -c "cd /app; sbt assembly; chown -R "${AIRFLOW_UID}:1000" target; chmod -R g+w target"
+    user: "0:1000"
     volumes:
       - .:/app
   
@@ -61,13 +62,13 @@ services:
     networks:
       - sparkpg_network
     entrypoint: /bin/bash
-    command: -c "/opt/spark/sbin/start-master.sh; tail -f /dev/null"
+    command: -c "/home/sparkuser/spark/sbin/start-master.sh; tail -f /dev/null"
     ports:
       - '8080:8080'
       - '4040:4040'
     volumes:
       - .:/app
-      - spark-events:/opt/spark/events
+      - spark-events:/home/sparkuser/spark/events
 
   spark-worker:
     image: my_first_spark
@@ -76,10 +77,10 @@ services:
     networks:
       - sparkpg_network
     entrypoint: /bin/bash
-    command: -c "/opt/spark/sbin/start-worker.sh  spark://spark-master:7077; tail -f /dev/null"
+    command: -c "/home/sparkuser/spark/sbin/start-worker.sh  spark://spark-master:7077; tail -f /dev/null"
     volumes:
       - .:/app
-      - spark-events:/opt/spark/events  
+      - spark-events:/home/sparkuser/spark/events
     
   spark-history-server:
     image: my_first_spark
@@ -88,9 +89,9 @@ services:
     networks:
       - sparkpg_network
     entrypoint: /bin/bash
-    command: -c "/opt/spark/sbin/start-history-server.sh; tail -f /dev/null"
+    command: -c "/home/sparkuser/spark/sbin/start-history-server.sh; tail -f /dev/null"
     volumes:
-      - spark-events:/opt/spark/events 
+      - spark-events:/home/sparkuser/spark/events
     ports:
       - '18080:18080'
 
@@ -296,7 +297,8 @@ services:
           fi
           mkdir -p /sources/logs /sources/dags /sources/plugins
           chown -R "${AIRFLOW_UID}:1000" /sources/{logs,dags,plugins}
-          chown -R "${AIRFLOW_UID}:1000" /opt/spark/events
+          chown -R "${AIRFLOW_UID}:1000" /home/sparkuser/spark/events; chmod -R g+w /home/sparkuser/spark/events
+          chown -R "${AIRFLOW_UID}:1000" /app/output; chmod -R g+w /app/output
           exec /entrypoint airflow version
       environment:
         <<: *airflow-common-env
@@ -307,7 +309,8 @@ services:
         _PIP_ADDITIONAL_REQUIREMENTS: ''
       user: "0:0"
       volumes:
-        - spark-events:/opt/spark/events
+        - ./output:/app/output
+        - spark-events:/home/sparkuser/spark/events
         - ${AIRFLOW_PROJ_DIR:-.}:/sources
 
   airflow-cli:

--- a/spark-defaults.conf
+++ b/spark-defaults.conf
@@ -3,13 +3,17 @@ spark.master                           spark://spark-master:7077
 # Enables Logging of events needed for History server
 spark.eventLog.enabled                 true
 # Output path for master and worker node events                      
-spark.eventLog.dir                     /opt/spark/events   
+spark.eventLog.dir                     /home/sparkuser/spark/events
 # Input path for history server      
-spark.history.fs.logDirectory          /opt/spark/events         
-
+spark.history.fs.logDirectory          /home/sparkuser/spark/events
+# Set static path for spark warehouse dir
+spark.sql.warehouse.dir                /home/sparkuser/spark/spark-warehouse
 # Set aws parameters
 spark.hadoop.fs.s3a.endpoint		http://minio:9000
 spark.hadoop.fs.s3a.impl		org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.hadoop.fs.s3a.access.key		testuser
 spark.hadoop.fs.s3a.secret.key		password
 spark.hadoop.fs.s3a.path.style.access		true
+
+# Set file permissions
+spark.hadoop.fs.permissions.umask-mode   002

--- a/src/main/scala/SparkParquetExample.scala
+++ b/src/main/scala/SparkParquetExample.scala
@@ -1,0 +1,22 @@
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object SparkParquetExample {
+  def main(args: Array[String]): Unit = {
+    if (args.length < 1) {
+      println("Usage: SparkParquetExample <output_directory>")
+      System.exit(1)
+    }
+
+    val outputDir: String = args.mkString("")
+    println(outputDir)
+    val spark: SparkSession = SparkSession.builder
+      .appName("sparkParquet")
+      .getOrCreate()
+
+    // Read data and print
+    import spark.implicits._
+    val data : DataFrame = Seq( (1,"name1") , (2,"name2") ).toDF("id","name")
+    data.write.mode("overwrite").parquet(outputDir.concat("/example_parquet_folder"))
+
+  }
+}


### PR DESCRIPTION
Added user with 1000 (default linux id) as sparkuser to spark and airflow docker images
Extended group permissions in airflow and spark images for shared files to include writing so that airflow:sparkuser combination will give both access.
Spark will now write as sparkuser sparkuser
Airflow will run and write as airflow:sparkuser
Airflow, Spark and local user will be able to read, write and delete files created by either of them.